### PR TITLE
Swap order of client_id and secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Use **OAuth Server** for providing [Publish-to-gist](https://github.com/nteract/
 ```bash
 git clone https://github.com/nteract/nteract-oauth
 npm install -g now
-now secrets add github_secret "insert secret here"
 now secrets add github_client_id "insert client id here"
+now secrets add github_secret "insert secret here"
 now -e GITHUB_CLIENT=@github_client_id -e GITHUB_SECRET=@github_secret
 now alias set (clipboard copy) oauth.nteract.io
 ```


### PR DESCRIPTION
The order of these on the oauth apps page on github shows client id first, secret second. I've made the order match here so you can read down the same in both cases. 😄