### PR TITLE
Provide error if the credentials aren't set

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
 /* Server code comes from https://www.npmjs.com/package/github-oauth */
+if(!process.env['GITHUB_CLIENT'] || !process.env['GITHUB_SECRET']) {
+  throw new Error("Required github credentials are not set, fix up the deployment for https://github.com/nteract/oauth-server");
+}
+
 const githubOAuth = require('github-oauth')({
   githubClient: process.env['GITHUB_CLIENT'],
   githubSecret: process.env['GITHUB_SECRET'],


### PR DESCRIPTION
It seems `now` started up without our secrets and id set sometime ago and so the github publishing was failing. This makes sure the entire server halts on startup if we don't have the credentials set.